### PR TITLE
Rename repository to MinimalCli

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,15 +66,15 @@ dotnet new minCli -n MyMinimalCliApp
 
 ## Advanced: Manually installing MinimalCli NuGet package
 
-Add a reference to the nuget package `MinimalCommandLine`.
+Add a reference to the nuget package `MinimalCli`.
 
-- Via csproj: `<PackageReference Include="MinimalCommandLine" Version="2.0.0.36" />`
-- Via dotnet cli: `dotnet package add MinimalCommandLine`
+- Via csproj: `<PackageReference Include="MinimalCli" Version="2.0.0.36" />`
+- Via dotnet cli: `dotnet package add MinimalCli`
 - Via Visual Studio Menu: 
     * Tools >
     * NuGet Package Manager > 
     * Manage NuGet Packages for Solution...
-    * Search for "MinimalCommandLine"
+    * Search for "MinimalCli"
     * Select the package
     * Select the project you want to install it into
     * Hit Install
@@ -307,7 +307,7 @@ builder
 
 ## Contributors - Getting Started
 
-`git clone https://github.com/dotnetKyle/MinimalCommandLine.git`
+`git clone https://github.com/dotnetKyle/MinimalCli.git`
 
 ### Using Visual Studio:
 

--- a/src/MinimalCli.Core/MinimalCli.Core.csproj
+++ b/src/MinimalCli.Core/MinimalCli.Core.csproj
@@ -9,7 +9,7 @@
 		<Authors>dotnetKyle</Authors>
 		<Description>A set of minimal builders that sits on top of the System.CommandLine namespace to give an experience similar to the ASP.Net Core minimal API builders.</Description>
 		<PackageProjectUrl></PackageProjectUrl>
-		<RepositoryUrl>https://github.com/dotnetKyle/MinimalCommandLine</RepositoryUrl>
+		<RepositoryUrl>https://github.com/dotnetKyle/MinimalCli</RepositoryUrl>
 		<PackageTags>Command; Line</PackageTags>
 		<DebugType>embedded</DebugType>
 		<RootNamespace>MinimalCli</RootNamespace>

--- a/src/MinimalCli.SourceGenerator/MinimalCli.SourceGenerator.csproj
+++ b/src/MinimalCli.SourceGenerator/MinimalCli.SourceGenerator.csproj
@@ -7,9 +7,9 @@
 		<PackageId>MinimalCli.SourceGenerator</PackageId>
 		<Title>Minimal Command Line Source Generator</Title>
 		<Authors>dotnetKyle</Authors>
-		<Description>A source generator for MinimalCommandLine. Enables the quick rigging of commands using a Handler attribute.</Description>
+		<Description>A source generator for MinimalCli. Enables the quick rigging of commands using a Handler attribute.</Description>
 		<PackageProjectUrl></PackageProjectUrl>
-		<RepositoryUrl>https://github.com/dotnetKyle/MinimalCommandLine</RepositoryUrl>
+		<RepositoryUrl>https://github.com/dotnetKyle/MinimalCli</RepositoryUrl>
 		<PackageTags>Command; Line</PackageTags>
 		<DebugType>embedded</DebugType>
 

--- a/src/MinimalCli.Templates/MinimalCli.Templates.csproj
+++ b/src/MinimalCli.Templates/MinimalCli.Templates.csproj
@@ -6,8 +6,8 @@
     <Authors>dotnetKyle</Authors>
     <Description>A working project starting point for a MinimalCli console application.</Description>
     <PackageTags>Command; Line; System.CommandLine; Minimal; Source Generator; Minimal CLI; CLI</PackageTags>
-    <PackageProjectUrl>https://github.com/dotnetKyle/MinimalCommandLine</PackageProjectUrl>
-		<RepositoryUrl>https://github.com/dotnetKyle/MinimalCommandLine</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/dotnetKyle/MinimalCli</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/dotnetKyle/MinimalCli</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
 
 		<!-- see: https://learn.microsoft.com/en-us/dotnet/core/tools/custom-templates#pack-a-template-into-a-nuget-package-nupkg-file -->

--- a/src/MinimalCli.Templates/content/console/Program.cs
+++ b/src/MinimalCli.Templates/content/console/Program.cs
@@ -1,4 +1,4 @@
-﻿// See https://github.com/dotnetKyle/MinimalCommandLine for more information
+﻿// See https://github.com/dotnetKyle/MinimalCli for more information
 using MinimalCli;
 
 var builder = new MinimalCommandLineBuilder(args);

--- a/src/MinimalCli/MinimalCli.csproj
+++ b/src/MinimalCli/MinimalCli.csproj
@@ -10,7 +10,7 @@
 		<Description>A source generator on top of System.CommandLine to minimize the boiler plate needed to get started. Just add a [Handler] attribute to a function to get started!</Description>
 		<PackageProjectUrl></PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<RepositoryUrl>https://github.com/dotnetKyle/MinimalCommandLine</RepositoryUrl>
+		<RepositoryUrl>https://github.com/dotnetKyle/MinimalCli</RepositoryUrl>
 		<PackageTags>Command; Line; System.CommandLine; Minimal; Source Generator; Minimal CLI; CLI</PackageTags>
 		<PackageReleaseNotes>Added a source generator to quickly rig up commands with minimal effort.</PackageReleaseNotes>
 		<DebugType>embedded</DebugType>


### PR DESCRIPTION
rename repository from MinimalCommandLine to MinimalCli, the same as the NuGet package